### PR TITLE
Fix metrics count in tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 * mlr
 * gawk
 * gnuplot
+* bash 4+
+
+Note for MacOS users: to get a recent enough version of `bash`, you will need to manually install it, e.g.
+
+```
+brew install bash
+```
+
+Then confirm the version with
+
+```
+/usr/bin/env bash --version
+```
+
+See issue #13 if you have suggetions to improve this.
 
 For convenience, you may want to add this repo to `$PATH` instead of using absolute paths.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ For convenience, you may want to add this repo to `$PATH` instead of using absol
 
 Below is a brief description of each job.
 
+### support-tooling.sh
+An interactive wrapper script for some of the more common/useful things you can do with this repo.  Run `support-tooling.sh` from within an extracted support script and a simple menu will guide the user.
+
 ### puppet-top-api-calls.sh
 
 Summarize the count, average duration, and 99th percentile duration of per endpoint in Puppet server and DB access logs per 30 minute interval.  Can also graph the count and average duration in `gnuplot`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # support-script-tooling
 
 ## Requirements
+* mlr
 * gawk
 * gnuplot
 

--- a/console_largest_facts.awk
+++ b/console_largest_facts.awk
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S gawk -f
+
+# Sample usage:
+# console_largest_facts.awk logs/puppetserver/puppetserver-access.log | sort -nr | cut -f2- -d ' ' | head
+
+# We'll just use $NF for now for speed.
+$7 ~ "classified/nodes" { print $NF " " $0 }

--- a/files/metrics_import.service
+++ b/files/metrics_import.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Oneshot service to auto import Puppet metrics
+Wants=metrics_import.timer
+
+[Service]
+Type=oneshot
+WorkingDirectory=/root/metrics_import/puppet_operational_dashboards
+ExecStart=/root/metrics_import/puppet_operational_dashboards/metrics_import.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -1,55 +1,99 @@
 #!/bin/bash
+set -o pipefail
 shopt -s nullglob
 
-for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg /opt/mft-automations/puppet_enterprise_support*tar /opt/mft-automations/puppet_enterprise_support*tar.gz; do
-   # Does the file have a 5 digit ticket number after puppet_enterprise_support_
-   has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]+_')
-   
-   if [[ $(find "$f" -mmin -2 2>/dev/null) ]]; then
-      echo "INFO: $f is still downloading (mtime < 2 minutes). Skipping..."
-      continue
-   fi
-   
-   if ! [[ $has_ticket ]]; then
-      echo "ERROR: no ticket ID found in $f"
-      mv "$f" /opt/mft-automations/err
-      continue
-   fi
+# ---------------------------
+# Config
+# ---------------------------
+SEND_SLACK=true                 # set to false to disable Slack posting
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"  # must come from environment when SEND_SLACK=true
 
-   if [[ "${f##*.}" == 'gpg' ]]; then
-     # Decrypt the file to the same location as the source, stripping the .gpg suffix
-     # Delete source file if it decrypts ok, otherwise move it to err/
-     if cat /root/.support_gpg | gpg --pinentry-mode loopback --passphrase-fd 0 --batch --yes --output "${f%.*}" --decrypt "$f"; then
-       rm -- "$f"
-       f="${f%.*}"
-     else
-       echo "ERROR: failed to decrypt $f"
-       mv "$f" /opt/mft-automations/err
-       continue
-     fi
-   fi
+# ---------------------------
+# Helpers
+# ---------------------------
+slack_post() {
+  # Usage: slack_post "message"
+  local msg="$1"
 
-   if ! tar tf "$f" | grep -q -m 1 'metrics\/.*json'; then
-      echo "No metrics found in $f.  Skipping"
+  # Only post if enabled and webhook present
+  [[ "$SEND_SLACK" == "true" ]] || return 0
+  [[ -n "$SLACK_WEBHOOK_URL" ]] || return 0
+
+  # Minimal JSON escaping for double-quotes, plus newlines -> \n
+  local esc="${msg//\\/\\\\}"
+  esc="${esc//\"/\\\"}"
+  esc="${esc//$'\n'/\\n}"
+
+  curl -sS -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":\"$esc\"}" \
+    "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || true
+}
+
+log() {
+  # Usage: log "message"
+  local msg="$1"
+  echo "$msg"
+  slack_post "$msg"
+}
+
+# ---------------------------
+# Main
+# ---------------------------
+for f in /opt/mft-automations/puppet_enterprise_support*gz \
+         /opt/mft-automations/puppet_enterprise_support*gz.gpg \
+         /opt/mft-automations/puppet_enterprise_support*tar \
+         /opt/mft-automations/puppet_enterprise_support*tar.gz; do
+
+  # Does the file have a 5 digit ticket number after puppet_enterprise_support_
+  has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]+_')
+
+  if [[ $(find "$f" -mmin -2 2>/dev/null) ]]; then
+    log "INFO: $f is still downloading (mtime < 2 minutes). Skipping..."
+    continue
+  fi
+
+  if ! [[ $has_ticket ]]; then
+    log "ERROR: no ticket ID found in $f"
+    mv "$f" /opt/mft-automations/err
+    continue
+  fi
+
+  if [[ "${f##*.}" == 'gpg' ]]; then
+    # Decrypt the file to the same location as the source, stripping the .gpg suffix
+    # Delete source file if it decrypts ok, otherwise move it to err/
+    if cat /root/.support_gpg | gpg --pinentry-mode loopback --passphrase-fd 0 --batch --yes --output "${f%.*}" --decrypt "$f"; then
       rm -- "$f"
-      continue
-   fi
-
-   # Strip the trailing _, then everything up to the last _ to get just the number
-   ticket="${has_ticket%_}"
-   ticket="${ticket##*_}"
-
-   _tmp="$(mktemp)"
-   /opt/puppetlabs/bolt/bin/bolt plan run puppet_operational_dashboards::load_metrics --targets localhost --run-as root influxdb_bucket="$ticket" support_script_file="$f" |& tee "$_tmp"
-
-   if ! grep -q 'Wrote batch of [[:digit:]]* metrics' "$_tmp"; then
-      echo "ERROR: failed to import metrics from $f"
+      f="${f%.*}"
+    else
+      log "ERROR: failed to decrypt $f"
       mv "$f" /opt/mft-automations/err
       continue
-   fi
+    fi
+  fi
 
-   rm -- "$_tmp"
-   rm -- "$f"
+  if ! tar tf "$f" | grep -q -m 1 'metrics\/.*json'; then
+    log "No metrics found in $f.  Skipping"
+    rm -- "$f"
+    continue
+  fi
+
+  # Strip the trailing _, then everything up to the last _ to get just the number
+  ticket="${has_ticket%_}"
+  ticket="${ticket##*_}"
+
+  _tmp="$(mktemp)"
+  /opt/puppetlabs/bolt/bin/bolt plan run puppet_operational_dashboards::load_metrics \
+    --targets localhost --run-as root influxdb_bucket="$ticket" support_script_file="$f" \
+    |& tee "$_tmp"
+
+  if ! grep -q 'Wrote batch of [[:digit:]]* metrics' "$_tmp"; then
+    log "ERROR: failed to import metrics from $f"
+    mv "$f" /opt/mft-automations/err
+    continue
+  fi
+
+  rm -- "$_tmp"
+  rm -- "$f"
 done
 
 # Delete sup scripts older than 30 days

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 shopt -s nullglob
 
-for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg; do
+for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg /opt/mft-automations/puppet_enterprise_support*tar; do
    # Does the file have a 5 digit ticket number after puppet_enterprise_support_
    has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]+_')
 

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 shopt -s nullglob
 
-for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg /opt/mft-automations/puppet_enterprise_support*tar; do
+for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg /opt/mft-automations/puppet_enterprise_support*tar /opt/mft-automations/puppet_enterprise_support*tar.gz; do
    # Does the file have a 5 digit ticket number after puppet_enterprise_support_
    has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]+_')
 

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -3,7 +3,7 @@ shopt -s nullglob
 
 for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg; do
    # Does the file have a 5 digit ticket number after puppet_enterprise_support_
-   has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]{5}_')
+   has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]+_')
 
    if ! [[ $has_ticket ]]; then
       echo "ERROR: no ticket ID found in $f"
@@ -47,4 +47,5 @@ for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/
    rm -- "$f"
 done
 
-find /opt/mft-automations/err/ -type f -name "puppet_enterprise_support*gz" -mtime +30 -delete
+# Delete sup scripts older than 30 days
+find /opt/mft-automations/err/ -type f -name "puppet_enterprise_support*gz" -mtime -30 -delete

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -33,3 +33,5 @@ for f in /opt/mft-automations/puppet_enterprise_support*gz; do
    rm -- "$_tmp"
    rm -- "$f"
 done
+
+find /opt/mft-automations/err/ -type f -name "puppet_enterprise_support*gz" -mtime +30 -delete

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -4,7 +4,12 @@ shopt -s nullglob
 for f in /opt/mft-automations/puppet_enterprise_support*gz /opt/mft-automations/puppet_enterprise_support*gz.gpg /opt/mft-automations/puppet_enterprise_support*tar /opt/mft-automations/puppet_enterprise_support*tar.gz; do
    # Does the file have a 5 digit ticket number after puppet_enterprise_support_
    has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]+_')
-
+   
+   if [[ $(find "$f" -mmin -2 2>/dev/null) ]]; then
+      echo "INFO: $f is still downloading (mtime < 2 minutes). Skipping..."
+      continue
+   fi
+   
    if ! [[ $has_ticket ]]; then
       echo "ERROR: no ticket ID found in $f"
       mv "$f" /opt/mft-automations/err

--- a/files/metrics_import.sh
+++ b/files/metrics_import.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+shopt -s nullglob
+
+for f in /opt/mft-automations/puppet_enterprise_support*gz; do
+   # Does the file have a 5 digit ticket number after puppet_enterprise_support_
+   has_ticket=$(echo "$f" | grep -Eo -- 'puppet_enterprise_support_[[:digit:]]{5}_')
+
+   if ! [[ $has_ticket ]]; then
+      echo "ERROR: no ticket ID found in $f"
+      mv "$f" /opt/mft-automations/err
+      continue
+   fi
+
+   if ! tar tf "$f" | grep -q -m 1 'metrics\/.*json'; then
+      echo "No metrics found in $f.  Skipping"
+      rm -- "$f"
+      continue
+   fi
+
+   # Strip the trailing _, then everything up to the last _ to get just the number
+   ticket="${has_ticket%_}"
+   ticket="${ticket##*_}"
+
+   _tmp="$(mktemp)"
+   /opt/puppetlabs/bolt/bin/bolt plan run puppet_operational_dashboards::load_metrics --targets localhost --run-as root influxdb_bucket="$ticket" support_script_file="$f" |& tee "$_tmp"
+
+   if ! grep -q 'Wrote batch of [[:digit:]]* metrics' "$_tmp"; then
+      echo "ERROR: failed to import metrics from $f"
+      mv "$f" /opt/mft-automations/err
+      continue
+   fi
+
+   rm -- "$_tmp"
+   rm -- "$f"
+done

--- a/files/metrics_import.timer
+++ b/files/metrics_import.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer to auto import Puppet metrics
+
+[Timer]
+OnCalendar=*-*-* *:0/10
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/mft_automation/README.md
+++ b/mft_automation/README.md
@@ -2,21 +2,24 @@
 ## Prerequisites
 
 * Install `git` and `bolt`
-* Create the metrics_import directory in `root`'s home directory
+* Create the required directories
 ```bash
-mkdir metrics_import
+mkdir -p /root/metrics_import /opt/mft-automations/{err,}
 ```
-* Clone operational dashboards to this directory
+* Clone operational dashboards and install requirements
 ```bash
-cd metrics_import
+cd /root/metrics_import
 git clone https://github.com/puppetlabs/puppet_operational_dashboards.git
+bolt module install --force
+/opt/puppetlabs/bolt/bin/gem install --user-install toml-rb
 ```
 
-* Save files/metrics_import.sh to the `puppet_operational_dashboards` directory created by the `git clone`
+* Save files/metrics_import.sh to `/root/metrics_import/puppet_operational_dashboards`
 
 ## Set up InfluxDB and Grafana
-* Run the `provision_dashboard` plan from `root`'s home directory
+* Run the `provision_dashboard` plan
 ```bash
+cd /root/metrics_import/puppet_operational_dashboards
 bolt plan run puppet_operational_dashboards::provision_dashboard --targets localhost
 ```
 

--- a/mft_automation/README.md
+++ b/mft_automation/README.md
@@ -20,6 +20,14 @@ git clone https://github.com/puppetlabs/puppet_operational_dashboards.git
 bolt plan run puppet_operational_dashboards::provision_dashboard --targets localhost
 ```
 
+## Set up GPG key and passphrase
+* Save the Support GPG key from 1pass to a file `key.asc`
+* Import it
+```bash
+gpg --import key.asc
+```
+* Save the key's passphrase to a file `/root/.support_gpg`
+
 ## Set up the service to import metrics from sup scripts
 * Save `files/metrics_import.service` to `/etc/systemd/system/metrics_import.service`
 * Save `files/metrics_import.timer` to `/etc/systemd/system/metrics_import.timer`

--- a/mft_automation/README.md
+++ b/mft_automation/README.md
@@ -1,0 +1,33 @@
+#TODO: create a Bolt plan to automate this
+## Prerequisites
+
+* Install `git` and `bolt`
+* Create the metrics_import directory in `root`'s home directory
+```bash
+mkdir metrics_import
+```
+* Clone operational dashboards to this directory
+```bash
+cd metrics_import
+git clone https://github.com/puppetlabs/puppet_operational_dashboards.git
+```
+
+* Save files/metrics_import.sh to the `puppet_operational_dashboards` directory created by the `git clone`
+
+## Set up InfluxDB and Grafana
+* Run the `provision_dashboard` plan from `root`'s home directory
+```bash
+bolt plan run puppet_operational_dashboards::provision_dashboard --targets localhost
+```
+
+## Set up the service to import metrics from sup scripts
+* Save `files/metrics_import.service` to `/etc/systemd/system/metrics_import.service`
+* Save `files/metrics_import.timer` to `/etc/systemd/system/metrics_import.timer`
+* Do a daemon-reload
+```bash
+systemctl daemon-reload
+```
+* Confirm the timer is running
+```bash
+systemctl status metrics_import.timer
+```

--- a/puppet-top-api-calls.sh
+++ b/puppet-top-api-calls.sh
@@ -49,15 +49,18 @@ if [[ $graph && $borrow ]]; then
   unset graph
 fi
 
+perl_command=(perl -ne '/^\S+ \S+ \S+ \[[^\]]+\] "[A-Z]+ [^ "]+? HTTP\/[0-9.]+" [0-9]{3} [0-9]+|- "[^"]*" "[^"]*"/ && print')
+
 for file in "$@"; do
   printf 'Processing: %s\n' "$file" >&2
 
   case "${file##*.}" in
     gz)
-      read_cmd=(gunzip -c)
+      read_cmd=("gunzip" "-c" "--" "$file")
       ;;
     *)
-      read_cmd=(cat)
+      # UUOC, but it makes setting up read_cmd easier
+      read_cmd=("cat" "--" "$file")
       ;;
   esac
 
@@ -65,7 +68,7 @@ for file in "$@"; do
     puppetserver-access*)
       if [[ $borrow ]]; then duration_field=0; else duration_field=2; fi
 
-      "${read_cmd[@]}" "$file" \
+      "${read_cmd[@]}" | "${perl_command[@]}" \
         | gawk -v n="$duration_field" \
           'BEGIN { print "date,path,duration" }
                {

--- a/puppetserver_largest_reports.awk
+++ b/puppetserver_largest_reports.awk
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S gawk -f
+
+# Sample usage:
+# puppetserver_largest_reports.awk logs/puppetserver/puppetserver-access.log | sort -nr | cut -f2- -d ' ' | head
+
+BEGIN { FPAT="([^ ]+)|(\"[^\"]+\")" }
+
+$6 ~ "/report" { print $12 " " $0 }

--- a/puppetserver_longest_borrows.awk
+++ b/puppetserver_longest_borrows.awk
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S gawk -f
+
+# Sample usage:
+# puppetserver_longest_borrows.awk logs/puppetserver/puppetserver-access.log | sort -nr | cut -f2- -d ' ' | head
+
+BEGIN { FPAT="([^ ]+)|(\"[^\"]+\")" }
+
+{ print $13 " " $0 }

--- a/puppetserver_longest_compiles.awk
+++ b/puppetserver_longest_compiles.awk
@@ -3,10 +3,10 @@
 # Sample usage:
 # echo "Average Count Hostname" && puppetserver_longest_compiles.awk logs/puppetserver/puppetserver.log | sort -rn | head | column -t
 
-/Compiled static catalog/ {
+/Compiled (static )?catalog/ {
   # Store the cumulative total and count for each hostname in arrays
-  name[$10] += $15
-  count[$10] += 1
+  name[$(NF - 6)] += $(NF-1)
+  count[$(NF - 6)] += 1
 }
 
 END {

--- a/support-tooling.sh
+++ b/support-tooling.sh
@@ -22,6 +22,26 @@ puppetserver_latest() {
   "$base_dir"/puppet-top-api-calls.sh -g "${_latest[0]}"
 }
 
+puppetserver_longest_borrows() {
+  latest_logs "puppetserver-access"
+  (( ${#_latest[@]} > 0 )) || {
+    warn 'No puppetserver-access.log found.' 'Please run me from the root of an extracted support script'
+    return
+  }
+
+  "$base_dir"/puppetserver_longest_borrows.awk "${_latest[0]}" | sort -nr | cut -f2- -d ' ' | head
+}
+
+puppetserver_largest_reports() {
+  latest_logs "puppetserver-access"
+  (( ${#_latest[@]} > 0 )) || {
+    warn 'No puppetserver-access.log found.' 'Please run me from the root of an extracted support script'
+    return
+  }
+
+  "$base_dir"/puppetserver_largest_reports.awk "${_latest[0]}" | sort -nr | cut -f2- -d ' ' | head
+}
+
 confirm_opt() {
   cur_opt=$1
   cur_menu=("$@")
@@ -33,9 +53,10 @@ confirm_opt() {
 comm_cmds() {
   declare -A local menu=(
     ['Plot latest puppetserver-access.log']=puppetserver_latest
+    ['Longest JRuby borrow times']=puppetserver_longest_borrows
+    ['Largest report submissions']=puppetserver_largest_reports
   )
 
-  #TODO: function
   select opt in "${!menu[@]}"; do
     confirm_opt "$opt" "${!menu[@]}" || {
       warn 'Please enter a valid number'

--- a/support-tooling.sh
+++ b/support-tooling.sh
@@ -6,10 +6,8 @@ warn() {
 }
 
 latest_logs() {
-  while IFS= read -rd '' line; do
-    _latest+=("${line#* }")
-  done < <(find . -type f -name "$1*" -printf '%T@ %p\0' | sort -znr)
-
+  # Absolutely terrible hack because the dev is too lazy to deal with non-GNU utilities
+  _latest=($(ls -t **/*"$1"*))
 }
 
 puppetserver_latest() {
@@ -67,6 +65,9 @@ comm_cmds() {
     break
   done
 }
+
+shopt -s globstar nullglob
+_tmp="$(mktemp)"
 
 base_dir="${BASH_SOURCE[0]%/*}"
 PS3="Select an option by number: "

--- a/support-tooling.sh
+++ b/support-tooling.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+#TODO: common.sh
+warn() {
+  printf '%s\n' "$@"
+}
+
+latest_logs() {
+  while IFS= read -rd '' line; do
+    _latest+=("${line#* }")
+  done < <(find . -type f -name "$1*" -printf '%T@ %p\0' | sort -znr)
+
+}
+
+puppetserver_latest() {
+  latest_logs "puppetserver-access"
+  (( ${#_latest[@]} > 0 )) || {
+    warn 'No puppetserver-access.log found.' 'Please run me from the root of an extracted support script'
+    return
+  }
+
+  "$base_dir"/puppet-top-api-calls.sh -g "${_latest[0]}"
+}
+
+confirm_opt() {
+  cur_opt=$1
+  cur_menu=("$@")
+  cur_menu=("${cur_menu[@]:1}")
+
+  [[ " ${cur_menu[@]} " =~ " $cur_opt " ]]
+}
+
+comm_cmds() {
+  declare -A local menu=(
+    ['Plot latest puppetserver-access.log']=puppetserver_latest
+  )
+
+  #TODO: function
+  select opt in "${!menu[@]}"; do
+    confirm_opt "$opt" "${!menu[@]}" || {
+      warn 'Please enter a valid number'
+      warn 'CTRL+C exits'
+      break
+    }
+    "${menu[$opt]}"
+    break
+  done
+}
+
+base_dir="${BASH_SOURCE[0]%/*}"
+PS3="Select an option by number: "
+declare -A main_menu=(
+  ['Common commands']=comm_cmds
+)
+
+while :; do
+  select opt in "${!main_menu[@]}"; do
+    confirm_opt "$opt" "${!main_menu[@]}" || {
+      warn 'Please enter a valid number'
+      warn 'CTRL+C exits'
+      break
+    }
+    "${main_menu[$opt]}"
+    break
+  done
+done

--- a/support-tooling.sh
+++ b/support-tooling.sh
@@ -40,6 +40,16 @@ puppetserver_largest_reports() {
   "$base_dir"/puppetserver_largest_reports.awk "${_latest[0]}" | sort -nr | cut -f2- -d ' ' | head
 }
 
+console_largest_facts() {
+  latest_logs "console-services-api-access"
+  (( ${#_latest[@]} > 0 )) || {
+    warn 'No console-services-api-access.log found.' 'Please run me from the root of an extracted support script'
+    return
+  }
+
+  "$base_dir"/console_largest_facts.awk "${_latest[0]}" | sort -nr | cut -f2- -d ' ' | head
+}
+
 confirm_opt() {
   cur_opt=$1
   cur_menu=("$@")
@@ -53,6 +63,7 @@ comm_cmds() {
     ['Plot latest puppetserver-access.log']=puppetserver_latest
     ['Longest JRuby borrow times']=puppetserver_longest_borrows
     ['Largest report submissions']=puppetserver_largest_reports
+    ['Largest fact sizes']=console_largest_facts
   )
 
   select opt in "${!menu[@]}"; do


### PR DESCRIPTION
Metrics detection no longer relies on exit code of tar command, but on elements in tar count.